### PR TITLE
Added alternative origin to cors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,8 @@ const port = process.env.PORT || 3000;
 
 app.use(
 	cors({
-		origin: 'http://localhost:5173',
+		//origin: 'http://localhost:5173',
+		origin: 'http://127.0.0.1:5173',
 	}),
 );
 app.use(express.json());

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,8 +10,8 @@ const port = process.env.PORT || 3000;
 
 app.use(
 	cors({
-		//origin: 'http://localhost:5173',
-		origin: 'http://127.0.0.1:5173',
+		origin: 'http://localhost:5173',
+		//origin: 'http://127.0.0.1:5173',
 	}),
 );
 app.use(express.json());


### PR DESCRIPTION
Some systems resolve localhost as ip addresses. Just added an alternative very common

app.use(
	cors({
		//origin: 'http://localhost:5173',
		origin: 'http://127.0.0.1:5173',
	}),
);
app.use(express.json());